### PR TITLE
get git version string in generate_deb.sh

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -5,6 +5,7 @@ ARG BUILD_NUMBER
 ARG DISTRIBUTION
 ARG ARCHITECTURE
 ARG COMMIT_ID
+ARG GIT_VER
 
 RUN echo "deb [trusted=yes] https://artifactory.ssrc.fi/artifactory/debian-public-local focal fog-sw" >> /etc/apt/sources.list
 
@@ -30,6 +31,7 @@ RUN params="-m $(realpath .) " \
     && [ ! "${DISTRIBUTION}" = "" ] && params="$params -d ${DISTRIBUTION}" || : \
     && [ ! "${ARCHITECTURE}" = "" ] && params="$params -a ${ARCHITECTURE}" || : \
     && [ ! "${COMMIT_ID}" = "" ] && params="$params -c ${COMMIT_ID}" || : \
+    && [ ! "${GIT_VER}" = "" ] && params="$params -g ${GIT_VER}" || : \
     && [ ! "${ROS}" = "" ] && params="$params -r" || : \
     && ./packaging/common/package.sh $params
 

--- a/generate_deb.sh
+++ b/generate_deb.sh
@@ -45,7 +45,10 @@ fi
 
 # Generate debian package
 iname=fogsw-${name,,}
-docker build --build-arg COMMIT_ID=$(git rev-parse HEAD) --build-arg BUILD_NUMBER=${GITHUB_RUN_NUMBER} --build-arg DISTRIBUTION=${DISTRIBUTION} -t ${iname} .
+docker build --build-arg COMMIT_ID=$(git rev-parse HEAD) \
+	--build-arg GIT_VER=$(git log --date=format:%Y%m%d --pretty=~git%cd.%h -n 1) \
+	--build-arg BUILD_NUMBER=${GITHUB_RUN_NUMBER} \
+	--build-arg DISTRIBUTION=${DISTRIBUTION} -t ${iname} .
 container_id=$(docker create ${iname} "")
 docker cp ${container_id}:/packages .
 docker rm ${container_id}


### PR DESCRIPTION
If git commands are run inside docker the packaging of fog_sw submodules does not work. This is because in the submodules the .git is not a directory but a file containing a link to root level modules directory. So, if only submodule dir is copied into docker container, the link to .git directory is broken and no git commands are available.