### PR TITLE
Add ARG ROS into Dockerfile.template for commandline param

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -7,6 +7,7 @@ ARG ARCHITECTURE
 ARG COMMIT_ID
 ARG GIT_VER
 ARG PACKAGE_SUBDIR
+ARG ROS
 
 # workaround for ROS GPG Key Expiration Incident
 RUN rm /etc/apt/sources.list.d/ros2-latest.list && \

--- a/generate_deb.sh
+++ b/generate_deb.sh
@@ -50,6 +50,7 @@ docker build --build-arg COMMIT_ID=$(git rev-parse HEAD) \
 	--build-arg GIT_VER=$(git log --date=format:%Y%m%d --pretty=~git%cd.%h -n 1) \
 	--build-arg BUILD_NUMBER=${GITHUB_RUN_NUMBER} \
 	--build-arg PACKAGE_SUBDIR=${sub_path} \
+	--build-arg ROS=${ROS} \
 	--build-arg DISTRIBUTION=${DISTRIBUTION} -t ${iname} .
 container_id=$(docker create ${iname} "")
 docker cp ${container_id}:/packages .


### PR DESCRIPTION
In case ros node does not need any module specific installs, the ROS arg can be given from command line instead of creating Dockerfile.deb just for that.