### PR TITLE
mandatory unit-tests when building .deb from ROS package

### DIFF
--- a/mod_specific/depthai_ctrl/Dockerfile.dep
+++ b/mod_specific/depthai_ctrl/Dockerfile.dep
@@ -5,8 +5,20 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
     libgstreamer-plugins-bad1.0-dev \
     libgstreamer-plugins-good1.0-dev \
     libgstrtspserver-1.0-dev \
+    libgstreamer-plugins-base1.0-0 \
+    libgstreamer-plugins-good1.0-0 \
+    gstreamer1.0-x \
     gstreamer1.0-rtsp \
+    gstreamer1.0-tools \
+    gstreamer1.0-vaapi \
+    gstreamer1.0-plugins-base \
+    gstreamer1.0-plugins-good \
+    gstreamer1.0-plugins-bad \
+    gstreamer1.0-plugins-ugly \
+    gstreamer1.0-plugins-rtp \
+    gstreamer1.0-plugins-base-apps \
     && rm -rf /var/lib/apt/lists/*
 
 ENV ROS=1
 
+ENV XDG_RUNTIME_DIR=/tmp

--- a/package.sh
+++ b/package.sh
@@ -145,6 +145,7 @@ EOF_CHANGELOG
 	&& [ ! "$distr" = "" ] && sed -i "s/@(Distribution)/${distr}/" debian/changelog.em || : \
 	&& bloom-generate rosdebian --os-name ubuntu --os-version focal --ros-distro foxy --process-template-files -i ${build_nbr}${git_version_string} \
 	&& sed -i 's/^\tdh_shlibdeps.*/& --dpkg-shlibdeps-params=--ignore-missing-info/g' debian/rules \
+	&& sed -i 's!dh_auto_test || true!dh_auto_test -- ARGS+=--verbose!g' debian/rules \
 	&& fakeroot debian/rules clean \
 	&& fakeroot debian/rules binary || exit 1
 


### PR DESCRIPTION
this PR:
- adds gstreamer dependencies, required to run actual gst pipelines inside unit-tests 
- makes `bloom-generate` unit-testing VERBOSE 
- breaks .deb build if testing fails
