### PR TITLE
Add gazebo-ros dependency for px4_sitl build

### DIFF
--- a/px4/sitl/Dockerfile
+++ b/px4/sitl/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
     libgazebo11-dev \
     fast-dds-gen \
     ninja-build \
+    ros-foxy-gazebo-ros \
     && pip3 install kconfiglib jsonschema \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Add gazebo-ros dependency for px4_sitl building to be able to build gps plugin with gps spoofing modifications
